### PR TITLE
switch lines

### DIFF
--- a/app/assets/javascripts/jquery.slick.js
+++ b/app/assets/javascripts/jquery.slick.js
@@ -2431,9 +2431,9 @@
             animSlide = targetSlide;
         }
 
-        _.animating = true;
-
         _.$slider.trigger('beforeChange', [_, _.currentSlide, animSlide]);
+
+        _.animating = true;
 
         oldSlide = _.currentSlide;
         _.currentSlide = animSlide;


### PR DESCRIPTION
Like this:
https://github.com/kenwheeler/slick/pull/2104#issuecomment-240941038

This is so that we can successfully throw an exception in the "beforeChange" event, which lets us prevent the normal logic of advancing slides.  This is useful so that we can remove the ad slide without advancing to the next slide (which makes us skip a slide)