### PR TITLE
add an instance variable that allows a beforeChange handler alter which slide is displayed after the transition.

### DIFF
--- a/app/assets/javascripts/jquery.slick.js
+++ b/app/assets/javascripts/jquery.slick.js
@@ -114,7 +114,8 @@
                 $list: null,
                 touchObject: {},
                 transformsEnabled: false,
-                unslicked: false
+                unslicked: false,
+                newAnimSlide: null
             };
 
             $.extend(_, _.initials);
@@ -2431,7 +2432,11 @@
             animSlide = targetSlide;
         }
 
+        _.newAnimSlide = animSlide
+        
         _.$slider.trigger('beforeChange', [_, _.currentSlide, animSlide]);
+
+        animSlide = _.newAnimSlide; //let beforeChange handler change the animslide
 
         _.animating = true;
 


### PR DESCRIPTION
add an instance variable that allows a beforeChange handler alter which slide is displayed after the transition.  The handler just needs to set `slick.newAnimSlide` to whichever slide index is desired, and the next slide will be the one at that index.